### PR TITLE
Fix E2E Tests Prisma Client Generation

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Generate Prisma client for tests
         run: |
           export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/dojopool_test"
-          yarn workspace @dojopool/api prisma:generate
+          npx prisma generate --schema=packages/prisma/schema.prisma
 
       - name: Build Docker images for E2E
         run: |
@@ -127,7 +127,7 @@ jobs:
       - name: Generate Prisma client
         run: |
           export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/dojopool_test"
-          yarn workspace @dojopool/api prisma:generate
+          npx prisma generate --schema=packages/prisma/schema.prisma
 
       - name: Build application
         run: yarn build:backend && cd apps/web && yarn build


### PR DESCRIPTION
This PR fixes the E2E Tests workflow failure where the Prisma client generation was failing due to workspace resolution issues.

**Problem:**
- CI was failing with 'Workspace @dojopool/api not found' error
- The yarn workspace command was not resolving properly in the CI environment

**Solution:**
- Replace \yarn workspace @dojopool/api prisma:generate\ with \
px prisma generate --schema=packages/prisma/schema.prisma\
- This bypasses the workspace resolution issue and directly generates the Prisma client

**Changes:**
- Updated both E2E test jobs (docker and traditional) in .github/workflows/e2e-tests.yml
- Uses npx to run prisma generate with explicit schema path

This should resolve the failing E2E Tests workflow and allow the CI pipeline to proceed.