### PR TITLE
Fix Missing Test Dependencies for Jest Setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,15 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
+    "@ungap/structured-clone": "^0.4.0",
     "@vitest/ui": "^3.2.4",
     "cypress": "^13.0.0",
+    "dotenv": "^16.4.5",
     "jsdom": "^27.0.0",
     "msw": "^2.11.3",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4",
-    "wait-on": "^7.0.0"
+    "wait-on": "^7.0.0",
+    "whatwg-fetch": "^3.6.20"
   }
 }


### PR DESCRIPTION
This PR fixes the Deploy workflow failure where unit tests were failing due to missing test dependencies.

**Problem:**
- Deploy workflow was failing with 'Failed to resolve import @ungap/structured-clone from jest.setup.ts'
- The jest.setup.ts file imports polyfills but the packages were not listed in dependencies
- This caused unit tests to fail during the Deploy workflow

**Solution:**
- Add @ungap/structured-clone@^0.4.0 for structuredClone polyfill
- Add whatwg-fetch@^3.6.20 for fetch polyfill
- These provide the required polyfills for test environment

**Changes:**
- Updated package.json to include missing test dependencies
- Maintains compatibility with existing test setup

This should resolve the Deploy workflow unit test failures and allow the pipeline to proceed.